### PR TITLE
build(k8s): explicit explicitly use HOST during the migration

### DIFF
--- a/.k8s.app.values.yml
+++ b/.k8s.app.values.yml
@@ -26,3 +26,14 @@ deployment:
 
 ingress:
   enabled: true
+  # NOTE(douglasduteil): explicitly use HOST during the migration
+  # Ensure that we do not override the existing prod
+  hosts:
+    - host: ${HOST}
+      paths:
+        - path: /
+          servicePort: "${PORT}"
+  tls:
+    - hosts:
+        - ${HOST}
+      secretName: ${CI_PROJECT_NAME}-crt


### PR DESCRIPTION
<img src=https://media.giphy.com/media/3kCWXdIiIiCdMSSQBD/giphy.gif width=693>

---

This `$HOST` in dev comes from 

https://github.com/SocialGouv/gitlab-ci-yml/blob/v15.5.0/autodevops_simple_app.yml#L133-L134 

in prod 

https://github.com/SocialGouv/gitlab-ci-yml/blob/v15.5.0/autodevops_simple_app.yml#L173-L176