### PR TITLE
fix: corrige le problème de format JSONB dans les tables employments et employments-reference

### DIFF
--- a/src/clients/employments.js
+++ b/src/clients/employments.js
@@ -10,12 +10,7 @@ export const findEmployment = async ({ hospitalId, year, month, headers }) => {
   const response = await fetch(API_URL + EMPLOYMENTS_ENDPOINT + `/${hospitalId}/${year}/${month}`, {
     headers: headers,
   })
-  const res = await handleAPIResponse2(response)
-
-  // bug Chrome/IE: some numbers are stored with comma and can't be parsed. Cast in Number before that.
-  Object.keys(res).forEach((key) => (res[key] = Number(res[key])))
-
-  return res
+  return handleAPIResponse2(response)
 }
 
 export const findLastEdit = async ({ hospitalId, headers }) => {
@@ -28,6 +23,7 @@ export const findLastEdit = async ({ hospitalId, headers }) => {
 export const updateEmployment = async ({ hospitalId, year, month, dataMonth }) => {
   const response = await fetch(API_URL + EMPLOYMENTS_ENDPOINT + `/${hospitalId}/${year}/${month}`, {
     body: JSON.stringify(dataMonth),
+    headers: { "Content-Type": "application/json" },
     method: METHOD_PUT,
   })
   await handleAPIResponse2(response)

--- a/src/components/EmploymentMonthData.js
+++ b/src/components/EmploymentMonthData.js
@@ -321,7 +321,7 @@ function useEmployments({ month, year, hospitalId }) {
   const handleChange = (event) => {
     event.preventDefault()
 
-    setDataMonth({ ...dataMonth, [event.target.name]: event.target.value })
+    setDataMonth({ ...dataMonth, [event.target.name]: Number(event.target.value) })
   }
 
   const handleSubmit = async (event) => {

--- a/src/knex/migrations/20210318171839_clean_employments.js
+++ b/src/knex/migrations/20210318171839_clean_employments.js
@@ -1,0 +1,31 @@
+// For historic reasons, the data_month in employments table were at start as string, with commas or points.
+const cleanAndNumberify = (input) => {
+  if (typeof input === "string") input = input.replace(",", ".")
+  return isNaN(input) ? null : Number(input)
+}
+
+exports.up = async function (knex) {
+  const rows = await knex("employments").select("id", "data_month")
+
+  rows.forEach(async (row) => {
+    // if data_month is already an object, nothing to do
+    if (typeof row.data_month === "string") {
+      const dataMonth = JSON.parse(row.data_month)
+      Object.keys(dataMonth).forEach((key) => (dataMonth[key] = cleanAndNumberify(dataMonth[key])))
+
+      try {
+        await knex("employments")
+          .where("id", row.id)
+          .update({ data_month: JSON.stringify(dataMonth) })
+      } catch (error) {
+        console.log(`Error for row.id ${row.id}`, error)
+      }
+    }
+  })
+
+  return Promise.resolve(42)
+}
+
+exports.down = function (knex) {
+  return Promise.resolve(42)
+}

--- a/src/knex/migrations/20210318171839_clean_json_employments.js
+++ b/src/knex/migrations/20210318171839_clean_json_employments.js
@@ -23,9 +23,9 @@ exports.up = async function (knex) {
     }
   })
 
-  return Promise.resolve(42)
+  return Promise.resolve("Fin de la mise à jour des données.")
 }
 
 exports.down = function (knex) {
-  return Promise.resolve(42)
+  return Promise.resolve("Nothing to do.")
 }

--- a/src/models/employments-references.js
+++ b/src/models/employments-references.js
@@ -3,19 +3,19 @@ import * as yup from "yup"
 import * as common from "./common"
 
 const JStoDBKeys = {
-  id: "id",
   hospitalId: "hospital_id",
-  year: "year",
+  id: "id",
   month: "month",
   reference: "reference",
+  year: "year",
 }
 
 const schema = yup.object().shape({
-  id: yup.number().positive().integer().nullable(),
   hospitalId: yup.number().positive().integer(),
-  year: yup.number().positive().integer(),
+  id: yup.number().positive().integer().nullable(),
   month: yup.string().length(2),
-  reference: yup.string(),
+  reference: yup.object(),
+  year: yup.number().positive().integer(),
 })
 
 export const { transform, transformAll, untransform, untransformAll, validate } = common.build({ JStoDBKeys, schema })

--- a/src/pages/administration/hospitals/[hid]/employments/[rid].js
+++ b/src/pages/administration/hospitals/[hid]/employments/[rid].js
@@ -64,7 +64,7 @@ const EmploymentsReferencesDetailPage = ({ data, currentUser }) => {
   const month = String(dateNow.month() + 1).padStart(2, "0")
 
   let defaultValues = {
-    startMonth: data ? { year: data.year, month: data.month } : { year, month },
+    startMonth: data ? { month: data.month, year: data.year } : { month, year },
   }
 
   if (data?.reference) {
@@ -102,6 +102,10 @@ const EmploymentsReferencesDetailPage = ({ data, currentUser }) => {
   }
 
   const onSubmit = async (formData) => {
+    Object.keys(formData.reference).forEach((key) => {
+      formData.reference[key] = Number(formData.reference[key])
+    })
+
     setSuccess("")
     setError("")
 
@@ -109,9 +113,9 @@ const EmploymentsReferencesDetailPage = ({ data, currentUser }) => {
       if (isEmpty(formErrors)) {
         let payload = {
           hospitalId: hid,
-          reference: JSON.stringify(formData.reference),
-          year: formData.startMonth.year,
           month: formData.startMonth.month?.toString().padStart(2, "0"),
+          reference: formData.reference,
+          year: formData.startMonth.year,
         }
 
         if (formData?.id) {
@@ -170,7 +174,10 @@ const EmploymentsReferencesDetailPage = ({ data, currentUser }) => {
                   <a>Retour à la liste</a>
                 </Button>
               </Link>
-              <Link href="/administration/hospitals/[hid]/employments/[rid]" as={`/administration/hospitals/${hid}/employments/new`}>
+              <Link
+                href="/administration/hospitals/[hid]/employments/[rid]"
+                as={`/administration/hospitals/${hid}/employments/new`}
+              >
                 <Button outline color="success">
                   <a>Ajouter</a>
                 </Button>
@@ -393,7 +400,7 @@ EmploymentsReferencesDetailPage.getInitialProps = async (ctx) => {
   if (!rid || isNaN(rid)) return { key: Number(new Date()) }
 
   try {
-    const data = await findReference({ hospitalId: hid, referencesId: rid, headers })
+    const data = await findReference({ headers, hospitalId: hid, referencesId: rid })
     return { data, key: Number(new Date()) }
   } catch (error) {
     logError("APP error", error)

--- a/src/pages/api/employments/[hospitalId]/[year]/[month]/index.js
+++ b/src/pages/api/employments/[hospitalId]/[year]/[month]/index.js
@@ -21,7 +21,7 @@ const handler = async (req, res) => {
       case METHOD_PUT: {
         checkValidUserWithPrivilege(EMPLOYMENT_MANAGEMENT, req, res)
 
-        const data = await req.body
+        const data = req.body
         const result = await update({ ...req.query, data })
 
         return result ? res.status(STATUS_200_OK).json(result) : sendNotFoundError(res)

--- a/src/services/employments/update.js
+++ b/src/services/employments/update.js
@@ -6,22 +6,22 @@ import { STATUS_400_BAD_REQUEST } from "../../utils/http"
 import { isValid } from "./common"
 
 export const update = async ({ year, month, hospitalId, data }) => {
-  if (!isValid({ year, month, hospitalId }) || !data)
+  if (!isValid({ hospitalId, month, year }) || !data)
     throw new APIError({
-      status: STATUS_400_BAD_REQUEST,
       message: "Bad request",
+      status: STATUS_400_BAD_REQUEST,
     })
 
   const result = await upsert({
     db: knex,
-    table: "employments",
-    object: {
-      hospital_id: hospitalId,
-      year,
-      month,
-      data_month: JSON.stringify(data),
-    },
     key: ["hospital_id", "year", "month"],
+    object: {
+      data_month: data,
+      hospital_id: hospitalId,
+      month,
+      year,
+    },
+    table: "employments",
   })
 
   return result


### PR DESCRIPTION
Un utilisateur avait un bug, car certaines données ETP pour son établissement étaient stockées sous forme de string avec des virgules, chose que Firefox accepte mais pas Chrome. 

Cela a fait apparaître le fait que les données JSONB étaient en fait un string, or on peut (et il est préférable) de directement stocker un objet dans la colonne JSONB.

