### PR TITLE
fix: pb build time variables in k8s for Matomo & Sentry

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,70 +4,67 @@ const images = require("remark-images")
 const emoji = require("remark-emoji")
 
 const withMDX = require("@next/mdx")({
-    extension: /\.mdx?$/,
-    options: {
-        mdPlugins: [images, emoji],
-    },
+  extension: /\.mdx?$/,
+  options: {
+    mdPlugins: [images, emoji],
+  },
 })
 
 const nextConfig = {
-    cssLoaderOptions: {
-        url: false,
+  cssLoaderOptions: {
+    url: false,
+  },
+  publicRuntimeConfig: {
+    // Will be available on both server and client. Needs getInitialProps on page to be available
+    // APP_BASE_URL variable is available on the deployment environment only
+    API_URL: process.env.APP_BASE_URL ? `${process.env.APP_BASE_URL}${process.env.API_URL}` : process.env.API_URL,
+    DEBUG_MODE: process.env.DEBUG_MODE,
+    FEATURE_FLAGS: {
+      administration: true,
+      directory: false,
+      export: true,
+      notification: false,
+      resources: false,
     },
-    env: {
-        // Build-time replaced env variables
-        SENTRY_DSN: process.env.SENTRY_DSN,
-        MATOMO_SITE_ID: process.env.MATOMO_SITE_ID,
-        MATOMO_URL: process.env.MATOMO_URL,
-    },
-    publicRuntimeConfig: {
-        // Will be available on both server and client. Needs getInitialProps on page to be available
-        // APP_BASE_URL variable is available on the deployment environment only
-        API_URL: process.env.APP_BASE_URL ? `${process.env.APP_BASE_URL}${process.env.API_URL}` : process.env.API_URL,
-        TEST_CURRENT_DATE: process.env.TEST_CURRENT_DATE,
-        DEBUG_MODE: process.env.DEBUG_MODE,
-        FEATURE_FLAGS: {
-            notification: false,
-            administration: true,
-            directory: false,
-            resources: false,
-            export: true,
-        },
-    },
-    serverRuntimeConfig: {
-        // Will only be available on the server side. Needs getInitialProps on page to be available
-        // DB_URI variable is available on the deployment environment only
-        JWT_SECRET: process.env.JWT_SECRET,
-        POSTGRES_SSL: process.env.POSTGRES_SSL,
-        DATABASE_URL: process.env.DB_URI || process.env.DATABASE_URL,
-    },
-    webpack: (config, { isServer, buildId, webpack }) => {
-        //config.optimization.minimizer = []
+    MATOMO_SITE_ID: process.env.MATOMO_SITE_ID,
+    MATOMO_URL: process.env.MATOMO_URL,
+    SENTRY_DSN: process.env.SENTRY_DSN,
+    TEST_CURRENT_DATE: process.env.TEST_CURRENT_DATE,
+  },
+  serverRuntimeConfig: {
+    DATABASE_URL: process.env.DB_URI || process.env.DATABASE_URL,
+    // Will only be available on the server side. Needs getInitialProps on page to be available
+    // DB_URI variable is available on the deployment environment only
+    JWT_SECRET: process.env.JWT_SECRET,
+    POSTGRES_SSL: process.env.POSTGRES_SSL,
+  },
+  webpack: (config, { isServer, buildId, webpack }) => {
+    //config.optimization.minimizer = []
 
-        config.plugins.push(
-            new webpack.DefinePlugin({
-                // looks like it doesnt work for some reason
-                "process.env.SENTRY_RELEASE": JSON.stringify(buildId),
-            }),
-        )
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        // looks like it doesnt work for some reason
+        "process.env.SENTRY_RELEASE": JSON.stringify(buildId),
+      }),
+    )
 
-        if (!isServer) {
-            config.resolve.alias["@sentry/node"] = "@sentry/browser"
-        }
+    if (!isServer) {
+      config.resolve.alias["@sentry/node"] = "@sentry/browser"
+    }
 
-        return config
-    },
+    return config
+  },
 }
 
 module.exports = withPlugins(
+  [
+    [withTM],
     [
-        [withTM],
-        [
-            withMDX,
-            {
-                pageExtensions: ["js", "jsx", "md", "mdx"],
-            },
-        ],
+      withMDX,
+      {
+        pageExtensions: ["js", "jsx", "md", "mdx"],
+      },
     ],
-    nextConfig,
+  ],
+  nextConfig,
 )

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -23,9 +23,9 @@ logInfo("----------- MEDLE configuration --------")
 logInfo("NODE_ENV", process.env.NODE_ENV)
 logInfo("DEBUG_MODE", publicRuntimeConfig.DEBUG_MODE)
 
-logInfo("SENTRY_DSN", process.env.SENTRY_DSN)
-logInfo("MATOMO_SITE_ID", process.env.MATOMO_SITE_ID)
-logInfo("MATOMO_URL", process.env.MATOMO_URL)
+logInfo("SENTRY_DSN", publicRuntimeConfig.SENTRY_DSN)
+logInfo("MATOMO_SITE_ID", publicRuntimeConfig.MATOMO_SITE_ID)
+logInfo("MATOMO_URL", publicRuntimeConfig.MATOMO_URL)
 
 logInfo("API_URL", publicRuntimeConfig.API_URL)
 logInfo("TEST_CURRENT_DATE", publicRuntimeConfig.TEST_CURRENT_DATE)
@@ -36,14 +36,14 @@ logInfo("DATABASE_URL", process.env.DATABASE_URL)
 logInfo("-----------------------------------------")
 
 Sentry.init({
-  dsn: process.env.SENTRY_DSN,
+  dsn: publicRuntimeConfig.SENTRY_DSN,
 })
 
 export default class MyApp extends App {
   componentDidMount() {
     initMatomo({
-      piwikUrl: process.env.MATOMO_URL,
-      siteId: process.env.MATOMO_SITE_ID,
+      piwikUrl: publicRuntimeConfig.MATOMO_URL,
+      siteId: publicRuntimeConfig.MATOMO_SITE_ID,
     })
   }
 

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -1,14 +1,19 @@
 // NOTE: This require will be replaced with `@sentry/browser`
 // client side thanks to the webpack config in next.config.js
+
+import getConfig from "next/config"
+
 const Sentry = require("@sentry/node")
 const SentryIntegrations = require("@sentry/integrations")
 
+const { publicRuntimeConfig } = getConfig()
+
 module.exports = (release = process.env.SENTRY_RELEASE) => {
   const sentryOptions = {
-    dsn: process.env.SENTRY_DSN,
-    release,
-    maxBreadcrumbs: 50,
     attachStacktrace: true,
+    dsn: publicRuntimeConfig.SENTRY_DSN,
+    maxBreadcrumbs: 50,
+    release,
   }
 
   // When we're developing locally


### PR DESCRIPTION
I try not to use build time variables anymore in next.config.js.

